### PR TITLE
生のsecretの値をconfigファイルに書くのではなく、AWSパラメータストアから読むように変更する

### DIFF
--- a/functions/saba_disambiguator/main.go
+++ b/functions/saba_disambiguator/main.go
@@ -107,7 +107,7 @@ func DoDisambiguate() error {
 		return err
 	}
 	svc := ssm.New(session.New(), &aws.Config{
-		Region: aws.String("ap-northeast-1"),
+		Region: aws.String(config.Region),
 	})
 
 	twitterConfig, err := getTwitterConfig(svc, *config)

--- a/functions/saba_disambiguator/main.go
+++ b/functions/saba_disambiguator/main.go
@@ -87,6 +87,9 @@ func DoDisambiguate() error {
 	})
 
 	twitterConfig, err := getTwitterConfig(svc, *config)
+	if err != nil {
+		return err
+	}
 
 	token := oauth1.NewToken(twitterConfig.AccessToken, twitterConfig.AccessSecret)
 	httpClient := oauth1.NewConfig(

--- a/functions/saba_disambiguator/main.go
+++ b/functions/saba_disambiguator/main.go
@@ -204,14 +204,14 @@ func DoDisambiguate() error {
 		ctx := context.Background()
 		bqClient, err := bigquery.NewClient(ctx, config.BigQueryConfig.ProjectId, option.WithCredentialsJSON([]byte(serviceAccountCredential)))
 		if err != nil {
-			panic(err)
+			return err
 		}
 		defer bqClient.Close()
 
 		u := bqClient.Dataset(config.BigQueryConfig.Dataset).Table(config.BigQueryConfig.Table).Inserter()
 		err = u.Put(ctx, itemsForBq)
 		if err != nil {
-			panic(err)
+			return err
 		}
 	}
 

--- a/functions/saba_disambiguator/main.go
+++ b/functions/saba_disambiguator/main.go
@@ -186,12 +186,12 @@ func DoDisambiguate() error {
 			fmt.Fprintf(os.Stderr, "%s\n", tweetPermalink)
 			err := slack.Send(slackConfig.WebhookUrlPositive, "", payload)
 			if err != nil {
-				return err
+				return err[0]
 			}
 		} else if (predLabel == sabadisambiguator.NEGATIVE) && (slackConfig.WebhookUrlNegative != "") {
 			err := slack.Send(slackConfig.WebhookUrlNegative, "", payload)
 			if err != nil {
-				return err
+				return err[0]
 			}
 		}
 	}

--- a/functions/saba_disambiguator/main.go
+++ b/functions/saba_disambiguator/main.go
@@ -152,7 +152,7 @@ func DoDisambiguate() error {
 	for _, t := range search.Statuses {
 		createdAt, err := t.CreatedAtTime()
 		if err != nil {
-			panic(err)
+			return err
 		}
 		if now.After(createdAt.Add(5 * time.Minute)) {
 			continue
@@ -160,7 +160,7 @@ func DoDisambiguate() error {
 
 		tweetJson, err := json.Marshal(t)
 		if err != nil {
-			panic(err)
+			return err
 		}
 		fv := sabadisambiguator.ExtractFeatures(t)
 		score := model.PredictScore(fv)
@@ -186,12 +186,12 @@ func DoDisambiguate() error {
 			fmt.Fprintf(os.Stderr, "%s\n", tweetPermalink)
 			err := slack.Send(slackConfig.WebhookUrlPositive, "", payload)
 			if err != nil {
-				panic(err)
+				return err
 			}
 		} else if (predLabel == sabadisambiguator.NEGATIVE) && (slackConfig.WebhookUrlNegative != "") {
 			err := slack.Send(slackConfig.WebhookUrlNegative, "", payload)
 			if err != nil {
-				panic(err)
+				return err
 			}
 		}
 	}

--- a/functions/saba_disambiguator/main.go
+++ b/functions/saba_disambiguator/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dghubble/go-twitter/twitter"
 	"github.com/dghubble/oauth1"
 	sabadisambiguator "github.com/syou6162/saba_disambiguator/lib"
+	"google.golang.org/api/option"
 )
 
 type ItemForBigQuery struct {
@@ -196,8 +197,12 @@ func DoDisambiguate() error {
 	}
 
 	if config.BigQueryConfig.ProjectId != "" && len(itemsForBq) > 0 {
+		serviceAccountCredential, err := getValueFromParameterStore(svc, config.BigQueryConfig.ParameterStoreNameServiceAccountCredential)
+		if err != nil {
+			return err
+		}
 		ctx := context.Background()
-		bqClient, err := bigquery.NewClient(ctx, config.BigQueryConfig.ProjectId)
+		bqClient, err := bigquery.NewClient(ctx, config.BigQueryConfig.ProjectId, option.WithCredentialsJSON([]byte(serviceAccountCredential)))
 		if err != nil {
 			panic(err)
 		}

--- a/functions/saba_disambiguator/main.go
+++ b/functions/saba_disambiguator/main.go
@@ -114,6 +114,11 @@ func DoDisambiguate() error {
 		return err
 	}
 
+	slackConfig, err := getSlackConfig(svc, *config)
+	if err != nil {
+		return err
+	}
+
 	token := oauth1.NewToken(twitterConfig.AccessToken, twitterConfig.AccessSecret)
 	httpClient := oauth1.NewConfig(
 		twitterConfig.ConsumerKey,

--- a/lib/config.go
+++ b/lib/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	SlackConfig    SlackConfig    `yaml:"slack"`
 	BigQueryConfig BigQueryConfig `yaml:"bigquery"`
 	Query          string         `yaml:"query"`
+	Region         string         `yaml:"region"`
 }
 
 func GetConfigFromFile(configPath string) (*Config, error) {

--- a/lib/config.go
+++ b/lib/config.go
@@ -19,9 +19,10 @@ type SlackConfig struct {
 }
 
 type BigQueryConfig struct {
-	ProjectId string `yaml:"projectId"`
-	Dataset   string `yaml:"dataset"`
-	Table     string `yaml:"table"`
+	ParameterStoreNameServiceAccountCredential string `yaml:"parameterStoreNameServiceAccountCredential"`
+	ProjectId                                  string `yaml:"projectId"`
+	Dataset                                    string `yaml:"dataset"`
+	Table                                      string `yaml:"table"`
 }
 
 type Config struct {

--- a/lib/config.go
+++ b/lib/config.go
@@ -7,15 +7,15 @@ import (
 )
 
 type TwitterConfig struct {
-	ConsumerKey    string `yaml:"consumerKey"`
-	ConsumerSecret string `yaml:"consumerSecret"`
-	AceessToken    string `yaml:"aceessToken"`
-	AccessSecret   string `yaml:"accessSecret"`
+	ParameterStoreNameConsumerKey    string `yaml:"parameterStoreNameConsumerKey"`
+	ParameterStoreNameConsumerSecret string `yaml:"parameterStoreNameConsumerSecret"`
+	ParameterStoreNameAccessToken    string `yaml:"parameterStoreNameAccessToken"`
+	ParameterStoreNameAccessSecret   string `yaml:"parameterStoreNameAccessSecret"`
 }
 
 type SlackConfig struct {
-	WebhookUrlPositive string `yaml:"webhookUrlPositive"`
-	WebhookUrlNegative string `yaml:"webhookUrlNegative"`
+	ParameterStoreNameWebhookUrlPositive string `yaml:"parameterStoreNameWebhookUrlPositive"`
+	ParameterStoreNameWebhookUrlNegative string `yaml:"parameterStoreNameWebhookUrlNegative"`
 }
 
 type BigQueryConfig struct {

--- a/template.yml
+++ b/template.yml
@@ -35,6 +35,12 @@ Resources:
                   - logs:PutLogEvents
                 Resource:
                   - arn:aws:logs:*:*:*
+              - Effect: "Allow"
+                Action:
+                  - "ssm:GetParameters"
+                  - "secretsmanager:GetSecretValue"
+                  - "kms:Decrypt"
+                Resource: "*"
               - Effect: Allow
                 Action:
                   - lambda:*

--- a/template.yml
+++ b/template.yml
@@ -11,9 +11,6 @@ Resources:
       CodeUri: functions/saba_disambiguator/build
       Timeout: 120
       Role: !GetAtt LambdaSabaDisambiguatorRole.Arn
-      Environment:
-        Variables:
-          GOOGLE_APPLICATION_CREDENTIALS: google_application_credentials.json
   LambdaSabaDisambiguatorRole:
     Type: AWS::IAM::Role
     Properties:

--- a/template.yml
+++ b/template.yml
@@ -37,7 +37,7 @@ Resources:
                   - arn:aws:logs:*:*:*
               - Effect: "Allow"
                 Action:
-                  - "ssm:GetParameters"
+                  - "ssm:GetParameter"
                   - "secretsmanager:GetSecretValue"
                   - "kms:Decrypt"
                 Resource: "*"


### PR DESCRIPTION
configファイルをgithubで管理したい場合、secretなどを書きたくないのでAWSパラメータストアから読み込むように方式を変更する。