### PR TITLE
パラメータ化して複数使い回しができるようにする

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 AWSCMD=aws cloudformation
 BUCKET_NAME ?= saba-disambiguator
+STACK_NAME ?= saba-disambiguator
+Lambda_Saba_Disambiguator_Rule_Name ?= MackerelSocialNextCron
 
 import-pos:
 	touch _pos.json pos.json && cat _pos.json pos.json | jq -r .id_str > pos_cache_ids
@@ -40,7 +42,8 @@ sam-package:
 sam-deploy:
 	${AWSCMD} deploy \
 		--template-file sam.yml \
-		--stack-name saba-disambiguator \
+		--stack-name ${STACK_NAME} \
+		--parameter-overrides LambdaSabaDisambiguatorRuleName=${Lambda_Saba_Disambiguator_Rule_Name} \
 		--capabilities CAPABILITY_IAM
 
 .PHONY: import learn sam-package sam-deploy

--- a/template.yml
+++ b/template.yml
@@ -1,6 +1,9 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
 Description: Create Lambda function by using AWS SAM.
+Parameters:
+  LambdaSabaDisambiguatorRuleName:
+    Type: String
 Resources:
   LambdaSabaDisambiguator:
     Type: AWS::Serverless::Function
@@ -46,7 +49,7 @@ Resources:
   LambdaSabaDisambiguatorRule:
     Type: AWS::Events::Rule
     Properties:
-      Name: MackerelSocialNextCron
+      Name: !Ref LambdaSabaDisambiguatorRuleName
       ScheduleExpression: rate(5 minutes)
       Targets:
         - Id: LambdaSabaDisambiguator


### PR DESCRIPTION
複数のクエリを流そうと思うと、CFnのスタック名を変える必要が出てくるのでパラメータ化して変更可能にしておく。