### PR TITLE
対象とするスクリーン名をオプションで与えられるようにした

### DIFF
--- a/functions/saba_disambiguator/build/config_sample.yml
+++ b/functions/saba_disambiguator/build/config_sample.yml
@@ -13,3 +13,6 @@ bigquery:
   projectId: my-project
   dataset: my_dataset
   table: my_table 
+screenNames:
+  - mackerelio
+  - mackerelio_jp

--- a/functions/saba_disambiguator/main.go
+++ b/functions/saba_disambiguator/main.go
@@ -106,7 +106,9 @@ func DoDisambiguate() error {
 		if err != nil {
 			return err
 		}
-		fv := sabadisambiguator.ExtractFeatures(t)
+		fv := sabadisambiguator.ExtractFeaturesWithOptions(t, sabadisambiguator.ExtractOptions{
+			ScreenNames: config.ScreenNames,
+		})
 		score := model.PredictScore(fv)
 		predLabel := model.Predict(fv)
 		item := ItemForBigQuery{

--- a/lib/config.go
+++ b/lib/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	BigQueryConfig BigQueryConfig `yaml:"bigquery"`
 	Query          string         `yaml:"query"`
 	Region         string         `yaml:"region"`
+	ScreenNames    []string       `yaml:"screenNames"`
 }
 
 func GetConfigFromFile(configPath string) (*Config, error) {


### PR DESCRIPTION
親issue:

## :question: タスクの背景(Why)

`"mackerel"` を含むスクリーンネームだけでは過剰に拾ってしまう状況だったので、対象となり得るスクリーンネームをconfigで与えられるようにしました。

## :pick: やったこと(What)

### configの変更

screenNamesで必要なスクリーンネームを複数設定できるように対応しました。

```yaml
---
twitter:
  ...
bigquery:
  ...
screenNames:
  - mackerelio
  - mackerelio_jp
```

省略された場合は、これまでと同じように `"mackerel"` を含んでいるもの全てを対象として扱います。

## :eyes: 重点的にレビューしてほしいところ・気になっているところ

- 過去の学習結果などがあるので、 `containsMackerelInScreenName` などのキー名はそのまま残していますが、これは変更しても影響ないものなのかどうか