### PR TITLE
Goモジュールのエラー修正

### DIFF
--- a/functions/saba_disambiguator/go.mod
+++ b/functions/saba_disambiguator/go.mod
@@ -1,4 +1,4 @@
-module main
+module github.com/syou6162/saba_disambiguator/functions/saba_disambiguator
 
 go 1.16
 

--- a/functions/saba_disambiguator/go.mod
+++ b/functions/saba_disambiguator/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/elazarl/goproxy v0.0.0-20200809112317-0581fc3aee2d // indirect
 	github.com/parnurzeal/gorequest v0.2.16 // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect
+	github.com/syou6162/saba_disambiguator v0.0.3 // indirect
 	google.golang.org/api v0.46.0
 	moul.io/http2curl v1.0.0 // indirect
 	saba_disambiguator v0.0.1

--- a/functions/saba_disambiguator/go.sum
+++ b/functions/saba_disambiguator/go.sum
@@ -197,6 +197,10 @@ github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81P
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/syou6162/saba_disambiguator v0.0.2 h1:21f1tlVuIU0wHlvPINt9566W39DnhCMGWf0k9pBaCsM=
+github.com/syou6162/saba_disambiguator v0.0.2/go.mod h1:ArffxqDe6zfhhO0/MURjREjRwteMZLexyCxtOkzOxRY=
+github.com/syou6162/saba_disambiguator v0.0.3 h1:FCaAcY4aXTWDolUB7TvyZzQsZHndhtRExIHRdqByNY4=
+github.com/syou6162/saba_disambiguator v0.0.3/go.mod h1:ArffxqDe6zfhhO0/MURjREjRwteMZLexyCxtOkzOxRY=
 github.com/urfave/cli/v2 v2.2.0/go.mod h1:SE9GqnLQmjVa0iPEY0f1w3ygNIYcIJ0OKPMoW2caLfQ=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/functions/saba_disambiguator/main.go
+++ b/functions/saba_disambiguator/main.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"time"
 
-	sabadisambiguator "saba_disambiguator/lib"
+	sabadisambiguator "github.com/syou6162/saba_disambiguator/lib"
 
 	"cloud.google.com/go/bigquery"
 	"github.com/ashwanthkumar/slack-go-webhook"


### PR DESCRIPTION
### やったこと

- **go.mod** などのimport path関連でビルドエラーになっていたコードを修正した
- #228 のコミットにタグ(v0.0.3)を打ってモジュールから参照できるようにした