### PR TITLE
GitHub Actionsのrunnerとcheckoutを更新

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,10 +5,10 @@ on: [push, pull_request]
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-16.04    
+    runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
-      uses: actions/checkout@master
+      uses: actions/checkout@v3
     - name: Build
       env:
         GOPATH: /home/runner/work/


### PR DESCRIPTION
* ubuntu-16.04は廃止となっていてCIが全滅していたので20.04に更新した
  * latestにしてもいいかなとは思うが、一旦はこれで
* actions/checkoutもmasterだったのでv3に変更した