### PR TITLE
CGO_ENABLED=0など追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ S3_PREFIX ?= saba-disambiguator
 STACK_NAME ?= saba-disambiguator
 LAMBDA_SABA_DISAMBIGUATOR_RULE_NAME ?= MackerelSocialNextCron
 
+export CGO_ENABLED := 0
+
 import-pos:
 	touch _pos.json pos.json && cat _pos.json pos.json | jq -r .id_str > pos_cache_ids
 	cat data/pos.txt | go run import_json.go pos_cache_ids | tee -a _pos.json

--- a/import_json.go
+++ b/import_json.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package main

--- a/import_json.go
+++ b/import_json.go
@@ -69,10 +69,6 @@ func main() {
 
 	stdin := bufio.NewScanner(os.Stdin)
 	for stdin.Scan() {
-		if err := stdin.Err(); err != nil {
-			fmt.Fprintln(os.Stderr, err)
-		}
-
 		text := stdin.Text()
 		id, err := parseLine(text)
 		if err != nil {
@@ -91,5 +87,8 @@ func main() {
 
 		tweetJson, _ := json.Marshal(tweet)
 		fmt.Println(string(tweetJson))
+	}
+	if err := stdin.Err(); err != nil {
+		log.Fatalln(err)
 	}
 }

--- a/train_perceptron.go
+++ b/train_perceptron.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package main

--- a/train_perceptron.go
+++ b/train_perceptron.go
@@ -6,6 +6,7 @@ package main
 import (
 	"bufio"
 	"encoding/json"
+	"log"
 	"os"
 
 	"github.com/dghubble/go-twitter/twitter"
@@ -45,14 +46,15 @@ func readExamplesFromFile(fileName string, label sabadisambiguator.LabelType) (s
 }
 
 func main() {
+	log.SetFlags(0)
 	examplesPos, err := readExamplesFromFile(os.Args[1], sabadisambiguator.POSITIVE)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to read %s: %v\n", os.Args[1], err)
 	}
 
 	examplesNeg, err := readExamplesFromFile(os.Args[2], sabadisambiguator.NEGATIVE)
 	if err != nil {
-		panic(err)
+		log.Fatalf("failed to read %s: %v\n", os.Args[2], err)
 	}
 
 	examples := append(examplesPos, examplesNeg...)


### PR DESCRIPTION
Linux環境でビルドするとlibcをリンクするが、Lambda環境には存在しないlibcをリンクする場合がある。
例えばArch Linuxでビルドすると **libc.so.6** をリンクするが、Lambdaにはこのバージョンが存在しないので実行エラーになる。
(macOSで `GOOS=linux` をビルドすると暗黙的に `CGO_ENABLED=0` となるので問題にならなかったが、*GOHOSTOS* と *GOOS* が同じ場合は0にならない)

ほか、 *panic* させないなどの対応も入れた。